### PR TITLE
update network/utils for multi-networks support

### DIFF
--- a/openood/networks/utils.py
+++ b/openood/networks/utils.py
@@ -42,36 +42,37 @@ def get_network(network_config):
     elif network_config.name == 'DRAEM':
         model = ReconstructiveSubNetwork(in_channels=3, out_channels=3)
         model_seg = DiscriminativeSubNetwork(in_channels=6, out_channels=2)
-        if network_config.pretrained:
-            model.load_state_dict(
-                torch.load(network_config.checkpoint + '.ckpt',
-                           map_location='cuda:0'))
-            model_seg.load_state_dict(
-                torch.load(network_config.checkpoint + '_seg.ckpt',
-                           map_location='cuda:0'))
-        if network_config.num_gpus > 1:
-            pass
-        if network_config.num_gpus > 0:
-            model.cuda()
-            model_seg.cuda()
-            torch.cuda.manual_seed(1)
-        return {'generative': model, 'discriminative': model_seg}
+        net = {'generative': model, 'discriminative': model_seg}
 
     else:
         raise Exception('Unexpected Network Architecture!')
 
     if network_config.pretrained:
-        net.load_state_dict(torch.load(network_config.checkpoint),
-                            strict=False)
-        print('Model Loading Completed!')
+        if type(net) is dict:
+            for subnet, checkpoint in zip(net.values(),
+                                          network_config.checkpoint):
+                subnet.load_state_dict(torch.load(checkpoint), strict=False)
+        else:
+            net.load_state_dict(torch.load(network_config.checkpoint),
+                                strict=False)
+        print('Model Loading {} Completed!'.format(network_config.name))
 
     if network_config.num_gpus > 1:
-        net = torch.nn.DataParallel(net,
-                                    device_ids=list(
-                                        range(network_config.num_gpus)))
+        if type(net) is dict:
+            for key, subnet in zip(net.keys(), net.values()):
+                net[key] = torch.nn.DataParallel(
+                    subnet, device_ids=list(range(network_config.num_gpus)))
+        else:
+            net = torch.nn.DataParallel(net,
+                                        device_ids=list(
+                                            range(network_config.num_gpus)))
 
     if network_config.num_gpus > 0:
-        net.cuda()
+        if type(net) is dict:
+            for subnet in net.values():
+                subnet.cuda()
+        else:
+            net.cuda()
         torch.cuda.manual_seed(1)
 
     cudnn.benchmark = True


### PR DESCRIPTION
### Update network/utils for multi-networks support:
* multiple networks will be stored in a dict
* the respective checkpoint files for each corresponding networks should be written in the config file as list. (see examples)

> checkpoint: ["./checkpoints/DRAEM_test_0.0001_700_bs8_bottle_.ckpt",   
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; "./checkpoints/DRAEM_test_0.0001_700_bs8_bottle__seg.ckpt"]

This checkpoint configs as to the networks defined by:

        model = ReconstructiveSubNetwork(in_channels=3, out_channels=3)
        model_seg = DiscriminativeSubNetwork(in_channels=6, out_channels=2)
        net = {'generative': model, 'discriminative': model_seg}

And the order of the checkpoint files listed should be corresponding to that of which you define the network in the openood/network/utils.py file.