### PR TITLE
Fix path to dataset files in OSR configurations.

### DIFF
--- a/configs/datasets/osr_cifar50/cifar50_seed1.yml
+++ b/configs/datasets/osr_cifar50/cifar50_seed1.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/train/train_cifar50_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/train/train_cifar100_50_seed1.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/val/val_cifar50_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/val/val_cifar100_50_seed1.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_id_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_id_seed1.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_cifar50/cifar50_seed1_osr.yml
+++ b/configs/datasets/osr_cifar50/cifar50_seed1_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_ood_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_id_seed1.txt
   osr:
     datasets: [cifar50]
     cifar50:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_ood_seed1.txt
+      imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_ood_seed1.txt

--- a/configs/datasets/osr_cifar50/cifar50_seed2.yml
+++ b/configs/datasets/osr_cifar50/cifar50_seed2.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/train/train_cifar50_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/train/train_cifar100_50_seed2.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/val/val_cifar50_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/val/val_cifar100_50_seed2.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_id_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_id_seed2.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_cifar50/cifar50_seed2_osr.yml
+++ b/configs/datasets/osr_cifar50/cifar50_seed2_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_ood_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_id_seed2.txt
   osr:
     datasets: [cifar50]
     cifar50:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_ood_seed2.txt
+      imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_ood_seed2.txt

--- a/configs/datasets/osr_cifar50/cifar50_seed3.yml
+++ b/configs/datasets/osr_cifar50/cifar50_seed3.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/train/train_cifar50_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/train/train_cifar100_50_seed3.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/val/val_cifar50_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/val/val_cifar100_50_seed3.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_id_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_id_seed3.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_cifar50/cifar50_seed3_osr.yml
+++ b/configs/datasets/osr_cifar50/cifar50_seed3_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_ood_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_id_seed3.txt
   osr:
     datasets: [cifar50]
     cifar50:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_ood_seed3.txt
+      imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_ood_seed3.txt

--- a/configs/datasets/osr_cifar50/cifar50_seed4.yml
+++ b/configs/datasets/osr_cifar50/cifar50_seed4.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/train/train_cifar50_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/train/train_cifar100_50_seed4.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/val/val_cifar50_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/val/val_cifar100_50_seed4.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_id_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_id_seed4.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_cifar50/cifar50_seed4_osr.yml
+++ b/configs/datasets/osr_cifar50/cifar50_seed4_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_ood_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_id_seed4.txt
   osr:
     datasets: [cifar50]
     cifar50:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_ood_seed4.txt
+      imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_ood_seed4.txt

--- a/configs/datasets/osr_cifar50/cifar50_seed5.yml
+++ b/configs/datasets/osr_cifar50/cifar50_seed5.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/train/train_cifar50_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/train/train_cifar100_50_seed5.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/val/val_cifar50_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/val/val_cifar100_50_seed5.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_id_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_id_seed5.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_cifar50/cifar50_seed5_osr.yml
+++ b/configs/datasets/osr_cifar50/cifar50_seed5_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_ood_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_id_seed5.txt
   osr:
     datasets: [cifar50]
     cifar50:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar50_ood_seed5.txt
+      imglist_pth: ./data/benchmark_imglist/osr_cifar50/test/test_cifar100_50_ood_seed5.txt

--- a/configs/datasets/osr_cifar6/cifar6_seed1.yml
+++ b/configs/datasets/osr_cifar6/cifar6_seed1.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/train/train_cifar6_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/train/train_cifar10_6_seed1.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/val/val_cifar6_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/val/val_cifar10_6_seed1.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_id_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_6_id_seed1.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_cifar6/cifar6_seed1_osr.yml
+++ b/configs/datasets/osr_cifar6/cifar6_seed1_osr.yml
@@ -13,9 +13,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_ood_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_6_id_seed1.txt
   osr:
     datasets: [cifar4]
     cifar4:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_ood_seed1.txt
+      imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_4_ood_seed1.txt

--- a/configs/datasets/osr_cifar6/cifar6_seed2.yml
+++ b/configs/datasets/osr_cifar6/cifar6_seed2.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/train/train_cifar6_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/train/train_cifar10_6_seed2.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/val/val_cifar6_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/val/val_cifar10_6_seed2.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_id_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_6_id_seed2.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_cifar6/cifar6_seed2_osr.yml
+++ b/configs/datasets/osr_cifar6/cifar6_seed2_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_ood_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_6_id_seed2.txt
   osr:
     datasets: [cifar4]
     cifar4:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_ood_seed2.txt
+      imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_4_ood_seed2.txt

--- a/configs/datasets/osr_cifar6/cifar6_seed3.yml
+++ b/configs/datasets/osr_cifar6/cifar6_seed3.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/train/train_cifar6_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/train/train_cifar10_6_seed3.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/val/val_cifar6_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/val/val_cifar10_6_seed3.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_id_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_6_id_seed3.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_cifar6/cifar6_seed3_osr.yml
+++ b/configs/datasets/osr_cifar6/cifar6_seed3_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_ood_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_6_id_seed3.txt
   osr:
     datasets: [cifar4]
     cifar4:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_ood_seed3.txt
+      imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_4_ood_seed3.txt

--- a/configs/datasets/osr_cifar6/cifar6_seed4.yml
+++ b/configs/datasets/osr_cifar6/cifar6_seed4.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/train/train_cifar6_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/train/train_cifar10_6_seed4.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/val/val_cifar6_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/val/val_cifar10_6_seed4.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_id_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_6_id_seed4.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_cifar6/cifar6_seed4_osr.yml
+++ b/configs/datasets/osr_cifar6/cifar6_seed4_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_ood_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_6_id_seed4.txt
   osr:
     datasets: [cifar4]
     cifar4:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_ood_seed4.txt
+      imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_4_ood_seed4.txt

--- a/configs/datasets/osr_cifar6/cifar6_seed5.yml
+++ b/configs/datasets/osr_cifar6/cifar6_seed5.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/train/train_cifar6_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/train/train_cifar10_6_seed5.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/val/val_cifar6_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/val/val_cifar10_6_seed5.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_id_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_6_id_seed5.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_cifar6/cifar6_seed5_osr.yml
+++ b/configs/datasets/osr_cifar6/cifar6_seed5_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_ood_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_6_id_seed5.txt
   osr:
     datasets: [cifar4]
     cifar4:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar6_ood_seed5.txt
+      imglist_pth: ./data/benchmark_imglist/osr_cifar6/test/test_cifar10_4_ood_seed5.txt

--- a/configs/datasets/osr_mnist6/mnist6_seed1.yml
+++ b/configs/datasets/osr_mnist6/mnist6_seed1.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/train/train_mnist6_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/train/train_mnist_6_seed1.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/val/val_mnist6_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/val/val_mnist_6_seed1.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_id_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_6_id_seed1.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_mnist6/mnist6_seed1_osr.yml
+++ b/configs/datasets/osr_mnist6/mnist6_seed1_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_ood_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_6_id_seed1.txt
   osr:
     datasets: [mnist4]
     mnist4:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_ood_seed1.txt
+      imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_4_ood_seed1.txt

--- a/configs/datasets/osr_mnist6/mnist6_seed2.yml
+++ b/configs/datasets/osr_mnist6/mnist6_seed2.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/train/train_mnist6_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/train/train_mnist_6_seed2.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/val/val_mnist6_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/val/val_mnist_6_seed2.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_id_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_6_id_seed2.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_mnist6/mnist6_seed2_osr.yml
+++ b/configs/datasets/osr_mnist6/mnist6_seed2_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_ood_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_6_id_seed2.txt
   osr:
     datasets: [mnist4]
     mnist4:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_ood_seed2.txt
+      imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_4_ood_seed2.txt

--- a/configs/datasets/osr_mnist6/mnist6_seed3.yml
+++ b/configs/datasets/osr_mnist6/mnist6_seed3.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/train/train_mnist6_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/train/train_mnist_6_seed3.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/val/val_mnist6_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/val/val_mnist_6_seed3.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_id_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_6_id_seed3.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_mnist6/mnist6_seed3_osr.yml
+++ b/configs/datasets/osr_mnist6/mnist6_seed3_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_ood_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_6_id_seed3.txt
   osr:
     datasets: [mnist4]
     mnist4:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_ood_seed3.txt
+      imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_4_ood_seed3.txt

--- a/configs/datasets/osr_mnist6/mnist6_seed4.yml
+++ b/configs/datasets/osr_mnist6/mnist6_seed4.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/train/train_mnist6_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/train/train_mnist_6_seed4.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/val/val_mnist6_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/val/val_mnist_6_seed4.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_id_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_6_id_seed4.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_mnist6/mnist6_seed4_osr.yml
+++ b/configs/datasets/osr_mnist6/mnist6_seed4_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_ood_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_6_id_seed4.txt
   osr:
     datasets: [mnist4]
     mnist4:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_ood_seed4.txt
+      imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_4_ood_seed4.txt

--- a/configs/datasets/osr_mnist6/mnist6_seed5.yml
+++ b/configs/datasets/osr_mnist6/mnist6_seed5.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/train/train_mnist6_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/train/train_mnist_6_seed5.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/val/val_mnist6_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/val/val_mnist_6_seed5.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_id_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_6_id_seed5.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_mnist6/mnist6_seed5_osr.yml
+++ b/configs/datasets/osr_mnist6/mnist6_seed5_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_ood_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_6_id_seed5.txt
   osr:
     datasets: [mnist4]
     mnist4:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist6_ood_seed5.txt
+      imglist_pth: ./data/benchmark_imglist/osr_mnist6/test/test_mnist_4_ood_seed5.txt

--- a/configs/datasets/osr_tin20/tin20_seed1.yml
+++ b/configs/datasets/osr_tin20/tin20_seed1.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/train/train_tin20_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/train/train_tin_20_seed1.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/val/val_tin20_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/val/val_tin_20_seed1.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_id_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_20_id_seed1.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_tin20/tin20_seed1_osr.yml
+++ b/configs/datasets/osr_tin20/tin20_seed1_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_ood_seed1.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_20_id_seed1.txt
   osr:
     datasets: [tin180]
     tin180:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_ood_seed1.txt
+      imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_180_ood_seed1.txt

--- a/configs/datasets/osr_tin20/tin20_seed2.yml
+++ b/configs/datasets/osr_tin20/tin20_seed2.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/train/train_tin20_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/train/train_tin_20_seed2.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/val/val_tin20_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/val/val_tin_20_seed2.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_id_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_20_id_seed2.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_tin20/tin20_seed2_osr.yml
+++ b/configs/datasets/osr_tin20/tin20_seed2_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_ood_seed2.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_20_id_seed2.txt
   osr:
     datasets: [tin180]
     tin180:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_ood_seed2.txt
+      imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_180_ood_seed2.txt

--- a/configs/datasets/osr_tin20/tin20_seed3.yml
+++ b/configs/datasets/osr_tin20/tin20_seed3.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/train/train_tin20_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/train/train_tin_20_seed3.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/val/val_tin20_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/val/val_tin_20_seed3.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_id_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_20_id_seed3.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_tin20/tin20_seed3_osr.yml
+++ b/configs/datasets/osr_tin20/tin20_seed3_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_ood_seed3.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_20_id_seed3.txt
   osr:
     datasets: [tin180]
     tin180:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_ood_seed3.txt
+      imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_180_ood_seed3.txt

--- a/configs/datasets/osr_tin20/tin20_seed4.yml
+++ b/configs/datasets/osr_tin20/tin20_seed4.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/train/train_tin20_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/train/train_tin_20_seed4.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/val/val_tin20_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/val/val_tin_20_seed4.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_id_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_20_id_seed4.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_tin20/tin20_seed4_osr.yml
+++ b/configs/datasets/osr_tin20/tin20_seed4_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_ood_seed4.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_20_id_seed4.txt
   osr:
     datasets: [tin180]
     tin180:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_ood_seed4.txt
+      imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_180_ood_seed4.txt

--- a/configs/datasets/osr_tin20/tin20_seed5.yml
+++ b/configs/datasets/osr_tin20/tin20_seed5.yml
@@ -16,18 +16,18 @@ dataset:
   train:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/train/train_tin20_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/train/train_tin_20_seed5.txt
     batch_size: 128
     shuffle: True
   val:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/val/val_tin20_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/val/val_tin_20_seed5.txt
     batch_size: 200
     shuffle: False
   test:
     dataset_class: ImglistDataset
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_id_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_20_id_seed5.txt
     batch_size: 200
     shuffle: False

--- a/configs/datasets/osr_tin20/tin20_seed5_osr.yml
+++ b/configs/datasets/osr_tin20/tin20_seed5_osr.yml
@@ -15,9 +15,9 @@ ood_dataset:
   split_names: [val, osr]
   val:
     data_dir: ./data/images_classic/
-    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_ood_seed5.txt
+    imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_20_id_seed5.txt
   osr:
     datasets: [tin180]
     tin180:
       data_dir: ./data/images_classic/
-      imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin20_ood_seed5.txt
+      imglist_pth: ./data/benchmark_imglist/osr_tin20/test/test_tin_180_ood_seed5.txt


### PR DESCRIPTION
It seems that the naming convention for files in data/benchmark_imglist has been changed. This small fix updates all OSR configuration files accordingly. Note that the val/test/osr split is a little confusing so please check that I didn't break anything ;)