### PR TITLE
update setup.py so that libmr w/o cache install can work

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ We appreciate all contributions to improve OpenOOD. We sincerely welcome communi
 OpenOOD now supports installation via pip.
 ```
 pip install git+https://github.com/Jingkang50/OpenOOD
+pip install libmr
+
 # optional, if you want to use CLIP
 # pip install git+https://github.com/openai/CLIP.git
 ```

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,22 @@ setuptools.setup(
     url='https://github.com/Jingkang50/OpenOOD',
     packages=setuptools.find_packages(),
     install_requires=[
-        'torch>=1.13.1', 'torchvision>=0.13', 'scikit-learn', 'json5',
-        'matplotlib', 'scipy', 'tqdm', 'pyyaml>=5.4.1', 'pre-commit',
-        'opencv-python>=4.4.0.46', 'imgaug>=0.4.0', 'pandas', 'diffdist>=0.1',
-        'Cython>=0.29.30', 'faiss-gpu>=1.7.2', 'gdown>=4.7.1', 'libmr>=0.1.9'
+        'torch>=1.13.1',
+        'torchvision>=0.13',
+        'scikit-learn',
+        'json5',
+        'matplotlib',
+        'scipy',
+        'tqdm',
+        'pyyaml>=5.4.1',
+        'pre-commit',
+        'opencv-python>=4.4.0.46',
+        'imgaug>=0.4.0',
+        'pandas',
+        'diffdist>=0.1',
+        'Cython>=0.29.30',
+        'faiss-gpu>=1.7.2',
+        'gdown>=4.7.1',  # 'libmr>=0.1.9'
     ],
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Like the title says. Earlier there was a bug where libmr expects numpy and cython as dependencies, yet setuptools will install all packages at the same time, and libmr's setup.py will raise an error. To fix this we remove libmr from setup.py and instead instruct users to install libmr as an extra step after OpenOOD (and other dependencies) has been intalled.