### PR TITLE
Downgrade numpy to fix faiss dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'torch>=1.13.1',
+        'numpy<2',
         'torchvision>=0.13',
         'scikit-learn',
         'json5',


### PR DESCRIPTION
Faiss is not yet [compatible with numpy>=2](https://github.com/facebookresearch/faiss/issues/3526), thus it is not able to be imported after running ```pip install git+https://github.com/Jingkang50/OpenOOD```. Currently, installing OpenOOD leads to the following output:

```
$ python3 -m venv env
$ source env/bin/activate
$ pip install git+https://github.com/Jingkang50/OpenOOD
$ pip install libmr
$ python
Python 3.10.14 (main, Aug 21 2024, 13:33:32) [GCC 14.2.1 20240805] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from openood.evaluation_api import Evaluator

A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.1.0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

Traceback (most recent call last):  File "<stdin>", line 1, in <module>
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/evaluation_api/__init__.py", line 1, in <module>
    from .evaluator import Evaluator
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/evaluation_api/evaluator.py", line 11, in <module>
    from openood.evaluators.metrics import compute_all_metrics
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/evaluators/__init__.py", line 1, in <module>
    from .utils import get_evaluator
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/evaluators/utils.py", line 1, in <module>
    from openood.evaluators.mos_evaluator import MOSEvaluator
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/evaluators/mos_evaluator.py", line 13, in <module>
    from openood.postprocessors import BasePostprocessor
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/postprocessors/__init__.py", line 4, in <module>
    from .cider_postprocessor import CIDERPostprocessor
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/postprocessors/cider_postprocessor.py", line 3, in <module>
    import faiss
  File "/home/jona/openood/env/lib/python3.10/site-packages/faiss/__init__.py", line 18, in <module>
    from .loader import *
  File "/home/jona/openood/env/lib/python3.10/site-packages/faiss/loader.py", line 65, in <module>
    from .swigfaiss import *
  File "/home/jona/openood/env/lib/python3.10/site-packages/faiss/swigfaiss.py", line 13, in <module>
    from . import _swigfaiss
AttributeError: _ARRAY_API not found
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/evaluation_api/__init__.py", line 1, in <module>
    from .evaluator import Evaluator
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/evaluation_api/evaluator.py", line 11, in <module>
    from openood.evaluators.metrics import compute_all_metrics
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/evaluators/__init__.py", line 1, in <module>
    from .utils import get_evaluator
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/evaluators/utils.py", line 1, in <module>
    from openood.evaluators.mos_evaluator import MOSEvaluator
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/evaluators/mos_evaluator.py", line 13, in <module>
    from openood.postprocessors import BasePostprocessor
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/postprocessors/__init__.py", line 4, in <module>
    from .cider_postprocessor import CIDERPostprocessor
  File "/home/jona/openood/env/lib/python3.10/site-packages/openood/postprocessors/cider_postprocessor.py", line 3, in <module>
    import faiss
  File "/home/jona/openood/env/lib/python3.10/site-packages/faiss/__init__.py", line 18, in <module>
    from .loader import *
  File "/home/jona/openood/env/lib/python3.10/site-packages/faiss/loader.py", line 65, in <module>
    from .swigfaiss import *
  File "/home/jona/openood/env/lib/python3.10/site-packages/faiss/swigfaiss.py", line 13, in <module>
    from . import _swigfaiss
ImportError: numpy.core.multiarray failed to import
```

Requiring ```numpy<2``` in ```setup.py``` fixes this.


Signed-off-by: Jonatan Hanssen <jonatan.hanssen@outlook.com>
