### PR TITLE
Fix erroneous relative path

### DIFF
--- a/openood/evaluation_api/evaluator.py
+++ b/openood/evaluation_api/evaluator.py
@@ -89,7 +89,7 @@ class Evaluator:
         # set up config root
         if config_root is None:
             filepath = os.path.dirname(os.path.abspath(__file__))
-            config_root = os.path.join(*filepath.split('/')[:-2], 'configs')
+            config_root = os.path.join('/', *filepath.split('/')[:-2], 'configs')
 
         # get postprocessor
         if postprocessor is None:


### PR DESCRIPTION
```openood/evaluation_api/evaluator.py``` uses ```filepath.split('/')``` on the absolute path of its own location, but this removes the first ```/```, making the path relative instead of absolute. This means that [openood/evaluation_api/postprocessor.py line 76](https://github.com/Jingkang50/OpenOOD/blob/3d7c483d88f15b514ea051799dde4a0cdce30d9c/openood/evaluation_api/postprocessor.py#L76) will always fail, because it is looking at ```$(pwd)/abolute/path/to/config``` as opposed to just the absolute path. It will then do a ```urllib.request``` and get the config file from github and create directories mirroring the absolute path in the current working directory. If you clone the repo in your home directory and create an Evaluator instance while in the repo, Evaluator will create the following directories and file: ```/home/user/OpenOOD/home/user/OpenOOD/configs/postprocessors/react.yml``` as opposed to getting ```react.yml``` from ```/home/user/OpenOOD/configs/postprocessors```.
