### PR TITLE
Fix: fix the hyperparam search of ViM

### DIFF
--- a/openood/postprocessors/vim_postprocessor.py
+++ b/openood/postprocessors/vim_postprocessor.py
@@ -54,7 +54,6 @@ class VIMPostprocessor(BasePostprocessor):
             pass
         
     def _compute_NS_and_alpha(self):
-        """根据当前的dim计算NS和alpha"""
         self.NS = np.ascontiguousarray(
             (self.eigen_vectors.T[np.argsort(self.eig_vals * -1)[self.dim:]]).T)
 


### PR DESCRIPTION
## Description

This PR fixes a bug in the hyperparameter search process for the ViM (Virtual-logit Matching) postprocessor.

### Problem

The current implementation has a bug where hyperparameter validation fails to work correctly:

1. The `setup()` method is only called once during the entire evaluation process
2. When `set_hyperparam()` is called to change the `dim` parameter, it sets `self.setup_flag = False`
3. However, `setup()` is never called again, so the dependent statistics (`self.NS` and `self.alpha`) are never recalculated
4. This results in all hyperparameter configurations using the statistics computed from the initial `dim` value, making hyperparameter search ineffective

### Root Cause

The `dim` parameter determines which eigenvectors are used to construct the null space (`NS`), which directly affects the `alpha` scaling factor. These values must be recalculated whenever `dim` changes, but the current code only computes them once during the initial `setup()` call.

### Solution

- Store intermediate computation results (`feature_id_train`, `eigen_vectors`, `eig_vals`, `logit_id_train`) in `setup()` to avoid redundant feature extraction
- Extract the `dim`-dependent computation into a separate `_compute_NS_and_alpha()` method
- Call `_compute_NS_and_alpha()` in `set_hyperparam()` to recalculate statistics when `dim` changes

This approach ensures that:
- Feature extraction (expensive operation) only happens once
- Statistics dependent on `dim` are correctly updated for each hyperparameter configuration
- Hyperparameter search now works as intended

### Testing

Verified that different `dim` values now produce different `alpha` values and OOD detection scores during hyperparameter validation.

---

**Changes made:**
- Modified `VIMPostprocessor.setup()` to store intermediate results
- Added `VIMPostprocessor._compute_NS_and_alpha()` method
- Updated `VIMPostprocessor.set_hyperparam()` to trigger recalculation